### PR TITLE
Update test.rs

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -199,6 +199,11 @@ mod fixtures {
     fn test_overlaps() {
         assert!(QuadTreeRegion::square(0.0, 0.0, 100.0).overlaps(&QuadTreeRegion::square(50.0, 50.0, 100.0)));
     }
+    #[test]
+    // test impl fails when other is totally contained by self.
+    fn test_overlaps2() {
+        assert!(QuadTreeRegion::square(0.0,0.0,100.0).overlaps(&QuadTreeRegion::square(50.0,50.0,49.0)));
+    }
 
     #[test]
     fn test_split() {


### PR DESCRIPTION
First pass at a soln is just:          
  let underlaps = |own:&QuadTreeRegion,other: &QuadTreeRegion|{
                other.contains(&Vec2 { x: own.x, y: own.y })
                    || other.contains(&Vec2 { x: own.x + own.width, y: own.y })
                    || other.contains(&Vec2 { x: own.x, y: own.y + own.height })
                    || other.contains(&Vec2 { x: own.x + own.width, y: own.y + own.height })
            };
            return underlaps(self,other) || underlaps(other,self);