### PR TITLE
remove unnecessary contains check from insert function, rewrite recursive function to iterative functions, use less memory by saving buckit size only once

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
-#![cfg_attr(feature = "bench", feature(test))]
+#![cfg_attr(test, feature(test))]
+#![cfg_attr(test, feature(rand))]
 
 
 //! A generic, n-dimensional quadtree for fast neighbor lookups on multiple axes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,10 @@ impl<P, R: Region<P>> NTree<R, P> {
     /// is within the n-tree and was inserted and false if not.
     pub fn insert(&mut self, point: P) -> bool {
         if !self.region.contains(&point) { return false }
-
+        self.insert_helper(point)
+    }
+    ///Invariant: self.contains(&point) returns true
+    fn insert_helper(&mut self, point: P) -> bool {
         match self.kind {
             Bucket { ref mut points, ref bucket_limit } => {
                 if points.len() as u8 != *bucket_limit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(feature = "bench", feature(test))]
 
+
 //! A generic, n-dimensional quadtree for fast neighbor lookups on multiple axes.
 
 extern crate ref_slice;
@@ -126,8 +127,8 @@ impl<P, R: Region<P>> NTreeNode<R, P> {
                         .unwrap(); //does always exist, due to invariant of R.split()
                 },
                 mut node  => {
-                    match node {
-                        &mut NTreeNode {region: _, kind: Bucket {ref mut points}} => {
+                    match node.kind {
+                        Bucket {ref mut points} => {
                             if points.len() as u8 != bucket_limit {
                                 points.push(point);
                                 return true;

--- a/src/test.rs
+++ b/src/test.rs
@@ -11,7 +11,7 @@ use self::test::Bencher;
 use self::rand::{random, XorShiftRng, Rng};
 
 use self::fixtures::{QuadTreeRegion, Vec2};
-use {NTree, Region};
+use {NTree};
 
 #[test]
 fn test_contains() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,14 +1,10 @@
-#[cfg(feature = "bench")]
 extern crate rand;
 
-#[cfg(feature = "bench")]
 extern crate test;
 
-#[cfg(feature = "bench")]
 use self::test::Bencher;
 
-#[cfg(feature = "bench")]
-use self::rand::{random, XorShiftRng, Rng};
+use self::rand::{XorShiftRng, Rng};
 
 use self::fixtures::{QuadTreeRegion, Vec2};
 use {NTree};
@@ -82,9 +78,9 @@ fn test_range_query() {
                     Vec2 { x: 60.0, y: 20.0 }]);
 }
 
-#[cfg(feature = "bench")]
+
 fn range_query_bench(b: &mut Bencher, n: usize) {
-    let mut rng: XorShiftRng = random();
+    let mut rng = XorShiftRng::new_unseeded();
 
     let mut ntree = NTree::new(QuadTreeRegion::square(0.0, 0.0, 1.0), 4);
     for _ in 0..n {
@@ -102,23 +98,45 @@ fn range_query_bench(b: &mut Bencher, n: usize) {
         for p in ntree.range_query(&r) { test::black_box(p); }
     })
 }
-
-#[cfg(feature = "bench")]
 #[bench]
 fn bench_range_query_small(b: &mut Bencher) {
     range_query_bench(b, 10);
 }
 
-#[cfg(feature = "bench")]
 #[bench]
 fn bench_range_query_medium(b: &mut Bencher) {
     range_query_bench(b, 100);
 }
 
-#[cfg(feature = "bench")]
 #[bench]
 fn bench_range_query_large(b: &mut Bencher) {
     range_query_bench(b, 10000);
+}
+
+
+fn insert_bench(b: &mut Bencher, n: usize) {
+    let mut rng = XorShiftRng::new_unseeded();
+    b.iter(|| {
+        let mut ntree = NTree::new(QuadTreeRegion::square(0.0, 0.0, 1.0), 4);
+        for _ in 0..n {
+            ntree.insert(Vec2 { x: rng.gen(), y: rng.gen() });
+        }
+    })
+}
+
+#[bench]
+fn bench_insert_small(b: &mut Bencher) {
+    insert_bench(b, 10);
+}
+
+#[bench]
+fn bench_insert_medium(b: &mut Bencher) {
+    insert_bench(b, 100);
+}
+
+#[bench]
+fn bench_insert_large(b: &mut Bencher) {
+    insert_bench(b, 10000);
 }
 
 mod fixtures {


### PR DESCRIPTION
As the title says: it removes an unnecessary call to the contains function, which speeds up insertions. This is even more important as the contains function can be arbitrarily complex.