### PR TITLE
Fix overlap algorithm

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -192,7 +192,7 @@ mod fixtures {
             self.x + self.width > other.x &&
             self.y < other.y + other.height &&
             self.y + self.height > other.y
-        }
+       }
     }
 
     #[test]
@@ -202,9 +202,20 @@ mod fixtures {
 
     #[test]
     fn test_overlaps() {
+        // Simple overlaps with corners in the other region
         assert!(QuadTreeRegion::square(0.0, 0.0, 100.0).overlaps(&QuadTreeRegion::square(50.0, 50.0, 100.0)));
         assert!(QuadTreeRegion::square(0.0, 0.0, 100.0).overlaps(&QuadTreeRegion::square(50.0, -50.0, 100.0)));
+        // Overlaps with no corners of one in the other region
         assert!(QuadTreeRegion::square(0.0, 0.0, 100.0).overlaps(&QuadTreeRegion::square(50.0, -50.0, 200.0)));
+        assert!(QuadTreeRegion::square(50.0, -50.0, 200.0).overlaps(&QuadTreeRegion::square(0.0, 0.0, 100.0)));
+        // Overlap with no corner in the other region
+        assert!(QuadTreeRegion { x:0.0, y: 50.0, width: 200.0, height: 10.0 }
+                    .overlaps(&QuadTreeRegion { x: 50.0, y: 0.0, width: 10.0, height: 200.0 }));
+        // No overlap
+        assert!(!QuadTreeRegion::square(0.0, 0.0, 100.0).overlaps(&QuadTreeRegion::square(300.0, -200.0, 100.0)));
+        assert!(!QuadTreeRegion::square(0.0, 0.0, 100.0).overlaps(&QuadTreeRegion::square(0.0, -200.0, 100.0)));
+        // Abutting counts as no overlap
+        assert!(!QuadTreeRegion::square(0.0, 0.0, 100.0).overlaps(&QuadTreeRegion::square(0.0, 100.0, 100.0)));
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -183,10 +183,10 @@ mod fixtures {
         }
 
         fn overlaps(&self, other: &QuadTreeRegion) -> bool {
-            other.contains(&Vec2 { x: self.x, y: self.y })
-                || other.contains(&Vec2 { x: self.x + self.width, y: self.y })
-                || other.contains(&Vec2 { x: self.x, y: self.y + self.height })
-                || other.contains(&Vec2 { x: self.x + self.width, y: self.y + self.height })
+            self.x < other.x + other.width &&
+            self.x + self.width > other.x &&
+            self.y < other.y + other.height &&
+            self.y + self.height > other.y
         }
     }
 
@@ -198,6 +198,8 @@ mod fixtures {
     #[test]
     fn test_overlaps() {
         assert!(QuadTreeRegion::square(0.0, 0.0, 100.0).overlaps(&QuadTreeRegion::square(50.0, 50.0, 100.0)));
+        assert!(QuadTreeRegion::square(0.0, 0.0, 100.0).overlaps(&QuadTreeRegion::square(50.0, -50.0, 100.0)));
+        assert!(QuadTreeRegion::square(0.0, 0.0, 100.0).overlaps(&QuadTreeRegion::square(50.0, -50.0, 200.0)));
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -11,7 +11,7 @@ use self::test::Bencher;
 use self::rand::{random, XorShiftRng, Rng};
 
 use self::fixtures::{QuadTreeRegion, Vec2};
-use {NTree, Region};
+use NTree;
 
 #[test]
 fn test_contains() {
@@ -23,7 +23,8 @@ fn test_contains() {
 fn test_insert() {
     let mut ntree = NTree::new(QuadTreeRegion::square(0.0, 0.0, 100.0), 4);
     assert!(ntree.insert(Vec2 { x: 50.0, y: 50.0 }));
-    assert_eq!(ntree.nearby(&Vec2 { x: 40.0, y: 40.0 }), Some(&[Vec2 { x: 50.0, y: 50.0 }] as &[_]));
+    let points = [Vec2 { x: 50.0, y: 50.0 }];
+    assert_eq!(ntree.nearby(&Vec2 { x: 40.0, y: 40.0 }), Some(&points[..]));
 }
 
 #[test]
@@ -45,19 +46,23 @@ fn test_nearby() {
     ntree.insert(Vec2 { x: 80.0, y: 20.0 });
 
     // Bottom left corner
+    let points = [Vec2 { x: 30.0, y: 30.0 },
+                  Vec2 { x: 20.0, y: 20.0 },
+                  Vec2 { x: 10.0, y: 10.0 }];
     assert_eq!(ntree.nearby(&Vec2 { x: 40.0, y: 40.0 }),
-        Some(&[Vec2 { x: 30.0, y: 30.0 },
-              Vec2 { x: 20.0, y: 20.0 },
-              Vec2 { x: 10.0, y: 10.0 }] as &[_]));
+                            Some(&points[..]));
 
     // Top right corner
-    assert_eq!(ntree.nearby(&Vec2 { x: 90.0, y: 90.0 }), Some(&[Vec2 { x: 75.0, y: 75.0 }] as &[_]));
+    let points = [Vec2 { x: 75.0, y: 75.0 }];
+    assert_eq!(ntree.nearby(&Vec2 { x: 90.0, y: 90.0 }), Some(&points[..]));
 
     // Top left corner
-    assert_eq!(ntree.nearby(&Vec2 { x: 20.0, y: 80.0 }), Some(&[Vec2 { x: 40.0, y: 70.0 }] as &[_]));
+    let points = [Vec2 { x: 40.0, y: 70.0 }];
+    assert_eq!(ntree.nearby(&Vec2 { x: 20.0, y: 80.0 }), Some(&points[..]));
 
     // Bottom right corner
-    assert_eq!(ntree.nearby(&Vec2 { x: 94.0, y: 12.0 }), Some(&[Vec2 { x: 80.0, y: 20.0 }] as &[_]));
+    let points = [Vec2 { x: 80.0, y: 20.0 }];
+    assert_eq!(ntree.nearby(&Vec2 { x: 94.0, y: 12.0 }), Some(&points[..]));
 }
 
 #[test]
@@ -122,7 +127,7 @@ fn bench_range_query_large(b: &mut Bencher) {
 }
 
 mod fixtures {
-    use {Region};
+    use Region;
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct QuadTreeRegion {


### PR DESCRIPTION
The product code looks good but the test code was bugged. This tests for that bug, fixes it, and also removes some warnings (mostly from changes in how you're meant to coerce a Vec to a Slice).